### PR TITLE
Clarify usage of Distributed Tracing Extension by OpenTelemetry

### DIFF
--- a/extensions/distributed-tracing.md
+++ b/extensions/distributed-tracing.md
@@ -17,7 +17,7 @@ Also from [OpenTelemetry specification](https://github.com/open-telemetry/opente
 
 ## Using the Distributed Tracing Extension
 
-The [OpenTelemetry Semantic Conventions for CloudEvents]() defines in which scenarios
+The [OpenTelemetry Semantic Conventions for CloudEvents](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/cloudevents.md) defines in which scenarios
 this extension should be used and how to use it.
 
 ## Attributes

--- a/extensions/distributed-tracing.md
+++ b/extensions/distributed-tracing.md
@@ -2,17 +2,24 @@
 
 This extension embeds context from
 [W3C TraceContext](https://www.w3.org/TR/trace-context/) into a CloudEvent.
+The objective of this extension is to carry context when instrumenting
+CloudEvent based systems with OpenTelemetry.
+
+The [OpenTelemetry](https://opentelemetry.io/) project is a collection
+of tools, APIs and SDKs that can be used to instrument, generate, collect,
+and export telemetry data (metrics, logs, and traces) to help you
+analyze your software’s performance and behavior.
 
 The [OpenTelemetry specification](
-https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/context.md#overview)
-defines context as:
+https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/context/context.md#overview)
+defines `context` as:
 
-> A Context is a propagation mechanism which carries execution-scoped values across
+> A `Context` is a propagation mechanism which carries execution-scoped values across
  API boundaries and between logically associated execution units. Cross-cutting
- concerns access their data in-process using the same shared Context object.
+ concerns access their data in-process using the same shared `Context` object.
 
-Context propagation enables `Distributed Tracing`.
-Also from [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#tracing-signal):
+Context propagation is what enables `Distributed Tracing`.
+Also from the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/overview.md#tracing-signal):
 
 > A distributed trace is a set of events, triggered as a result of a single
  logical operation, consolidated across various components of an application.
@@ -21,8 +28,8 @@ Also from [OpenTelemetry specification](https://github.com/open-telemetry/opente
 ## Using the Distributed Tracing Extension
 
 The
-[OpenTelemetry Semantic Conventions for CloudEvents](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/cloudevents.md)
-defines in which scenarios this extension should be used and how to use it.
+[OpenTelemetry Semantic Conventions for CloudEvents](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.9.0/specification/trace/semantic_conventions/cloudevents.md)
+define in which scenarios this extension should be used and how to use it.
 
 ## Attributes
 

--- a/extensions/distributed-tracing.md
+++ b/extensions/distributed-tracing.md
@@ -2,26 +2,25 @@
 
 This extension embeds context from
 [W3C TraceContext](https://www.w3.org/TR/trace-context/) into a CloudEvent.
-The objective of this extension is to carry context when instrumenting
-CloudEvent based systems with OpenTelemetry.
+The goal of this extension is to offer means to carry context when instrumenting
+CloudEvents based systems with OpenTelemetry.
 
 The [OpenTelemetry](https://opentelemetry.io/) project is a collection
 of tools, APIs and SDKs that can be used to instrument, generate, collect,
 and export telemetry data (metrics, logs, and traces) to help you
 analyze your software’s performance and behavior.
 
-The [OpenTelemetry specification](
-https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/context/context.md#overview)
-defines `context` as:
+The OpenTelemetry specification defines both
+[Context](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/context/context.md#overview)
+and
+[Distributed Tracing](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/overview.md#tracing-signal)
+as:
 
 > A `Context` is a propagation mechanism which carries execution-scoped values across
  API boundaries and between logically associated execution units. Cross-cutting
  concerns access their data in-process using the same shared `Context` object.
-
-Context propagation is what enables `Distributed Tracing`.
-Also from the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/overview.md#tracing-signal):
-
-> A distributed trace is a set of events, triggered as a result of a single
+>
+> A `Distributed Trace` is a set of events, triggered as a result of a single
  logical operation, consolidated across various components of an application.
  A distributed trace contains events that cross process, network and security boundaries.
 

--- a/extensions/distributed-tracing.md
+++ b/extensions/distributed-tracing.md
@@ -1,11 +1,24 @@
 # Distributed Tracing extension
 
-This extension embeds context from
-[Distributed Tracing](https://w3c.github.io/trace-context/) so that distributed
-systems can include traces that span an event-driven system. This extension is
-meant to contain historical data of the parent trace, in order to diagnose
-eventual failures of the system through tracing platforms like Jaeger, Zipkin,
-etc.
+This extension embeds context from 
+[W3C TraceContext](https://www.w3.org/TR/trace-context/) into a CloudEvent.
+
+The [OpenTelemetry specification](
+https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/context.md#overview)
+defines context as:
+
+> A Context is a propagation mechanism which carries execution-scoped
+ values across API boundaries and between logically associated execution units. Cross-cutting concerns access their data in-process using the same shared Context object.
+
+Context propagation enables `Distributed Tracing`.
+Also from [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#tracing-signal):
+
+> A distributed trace is a set of events, triggered as a result of a single logical operation, consolidated across various components of an application. A distributed trace contains events that cross process, network and security boundaries.
+
+## Using the Distributed Tracing Extension
+
+The [OpenTelemetry Semantic Conventions for CloudEvents]() defines in which scenarios
+this extension should be used and how to use it.
 
 ## Attributes
 
@@ -13,7 +26,7 @@ etc.
 
 - Type: `String`
 - Description: Contains a version, trace ID, span ID, and trace options as
-  defined in [section 3.2](https://w3c.github.io/trace-context/#traceparent-header)
+  defined in [section 3.2](https://www.w3.org/TR/trace-context/#traceparent-header)
 - Constraints
   - REQUIRED
 
@@ -21,35 +34,6 @@ etc.
 
 - Type: `String`
 - Description: a comma-delimited list of key-value pairs, defined by
-  [section 3.3](https://w3c.github.io/trace-context/#tracestate-header).
+  [section 3.3](https://www.w3.org/TR/trace-context/#tracestate-header).
 - Constraints
   - OPTIONAL
-
-## Using the Distributed Tracing Extension
-
-The Distributed Tracing Extension is not intended to replace the protocol specific headers for tracing, 
-like the ones described in [W3C Trace Context](https://w3c.github.io/trace-context/) for HTTP.
-
-Given a single hop event transmission (from sink to source directly), the Distributed Tracing Extension, 
-if used, MUST carry the same trace information contained in protocol specific tracing headers.
-
-Given a multi hop event transmission, the Distributed Tracing Extension, if used, MUST 
-carry the trace information of the starting trace of the transmission. 
-In other words, it MUST NOT carry trace information of each individual hop, since this information is usually 
-carried using protocol specific headers, understood by tools like [OpenTelemetry](https://opentelemetry.io/).
- 
-Middleware between the source and the sink of the event could eventually add a Distributed Tracing Extension
-if the source didn't include any, in order to provide to the sink the starting trace of the transmission.
-
-An example with HTTP:
-
-```bash
-CURL -X POST example/webhook.json \
--H 'ce-id: 1' \
--H 'ce-specversion: 1.0' \
--H 'ce-type: example' \
--H 'ce-source: http://localhost' \
--H 'ce-traceparent:  00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01' \
--H 'traceparent:  00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01' \
--H 'tracestate: rojo=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01,congo=lZWRzIHRoNhcm5hbCBwbGVhc3VyZS4`
-```

--- a/extensions/distributed-tracing.md
+++ b/extensions/distributed-tracing.md
@@ -1,28 +1,32 @@
 # Distributed Tracing extension
 
-This extension embeds context from 
+This extension embeds context from
 [W3C TraceContext](https://www.w3.org/TR/trace-context/) into a CloudEvent.
 
 The [OpenTelemetry specification](
 https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/context.md#overview)
 defines context as:
 
-> A Context is a propagation mechanism which carries execution-scoped
- values across API boundaries and between logically associated execution units. Cross-cutting concerns access their data in-process using the same shared Context object.
+> A Context is a propagation mechanism which carries execution-scoped values across
+ API boundaries and between logically associated execution units. Cross-cutting
+ concerns access their data in-process using the same shared Context object.
 
 Context propagation enables `Distributed Tracing`.
 Also from [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#tracing-signal):
 
-> A distributed trace is a set of events, triggered as a result of a single logical operation, consolidated across various components of an application. A distributed trace contains events that cross process, network and security boundaries.
+> A distributed trace is a set of events, triggered as a result of a single
+ logical operation, consolidated across various components of an application.
+ A distributed trace contains events that cross process, network and security boundaries.
 
 ## Using the Distributed Tracing Extension
 
-The [OpenTelemetry Semantic Conventions for CloudEvents](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/cloudevents.md) defines in which scenarios
-this extension should be used and how to use it.
+The
+[OpenTelemetry Semantic Conventions for CloudEvents](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/cloudevents.md)
+defines in which scenarios this extension should be used and how to use it.
 
 ## Attributes
 
-#### traceparent
+### traceparent
 
 - Type: `String`
 - Description: Contains a version, trace ID, span ID, and trace options as
@@ -30,7 +34,7 @@ this extension should be used and how to use it.
 - Constraints
   - REQUIRED
 
-#### tracestate
+### tracestate
 
 - Type: `String`
 - Description: a comma-delimited list of key-value pairs, defined by


### PR DESCRIPTION
From the last messaging workgroup meeting, it was pointed out that now that we are close to merge the [CloudEvents Semantic Conventions PR](https://github.com/open-telemetry/opentelemetry-specification/pull/1978), we should make it clear in the CloudEvents spec that the Distributed Tracing Extension is used by OTel. 

The reason for this "linking" between specs is that the extension caused confusion in the past and was even asked to be removed: https://github.com/cloudevents/spec/pull/751. Basically the idea is that OpenTelemetry "claims" this extension and by providing the semantic conventions, its usage becomes more clear. 

Here is the recording of the meeting where this subject came up: https://youtu.be/gjz3Fz_hz_8?t=937

So, in this PR I intended to:

- Remove instructions and extra clarifications on how this is used - It's now in the semantic conventions
- Clear some wording (context, propagation, distributed tracing) by using the text from the OpenTelemetry specification. (For the case people aren't aware of OpenTelemetry nor heard these terms before)
- Add link to the semantic conventions document where users will find out how to use it